### PR TITLE
fix: adapterHash on eth-usd aggregator

### DIFF
--- a/aggregator/baobab/eth-usd.aggregator.json
+++ b/aggregator/baobab/eth-usd.aggregator.json
@@ -1,9 +1,9 @@
 {
-  "aggregatorHash": "0xfda8c08a8b7641e001ad23c0fb363a9e7aab1e3a7eb8a6ddee41deeb7e3ef279",
+  "aggregatorHash": "0x9258ddf37ae6c47ef4a87e7b855b828e07e5cf28f4f404238bbac96a91020bfb",
   "name": "ETH-USD",
   "address": "0x15c0b3ea93ed4de0a1f93f4ae130aefd8f2e8ccb",
   "heartbeat": 15000,
   "threshold": 0.05,
   "absoluteThreshold": 0.1,
-  "adapterHash": "0x7e6552824ce107ab0d6e4266ba6b93f0afe5aa576a491364fc01881a34ddb12b"
+  "adapterHash": "0x0b754850b753b9eca61724dc780c02d5f9a62a08c8853b80a213a03d85e35729"
 }


### PR DESCRIPTION
This PR is ready to merge.

Changes:

-update `ETH-USD` adapter hash value