### PR TITLE
Remove Bittrex TRX-USDT data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [MATIC-USDT](adapter/matic-usdt.adapter.json) | 0xaac691986b90ba59358d2b8bff58036bcfea21cbd9f82ab08915902bdb00cdb1 | 8        | 10    |
 | [SHIB-USDT](adapter/shib-usdt.adapter.json)   | 0x8300f3385e5843e0da2504964067ab0d81de054550826e60577602e50cffe48c | 8        | 8     |
 | [SOL-USDT](adapter/sol-usdt.adapter.json)     | 0xf8ba3eafdf66c135dcd093dbb1bfdb10dca956ee3c75b510f76407353eb251d0 | 8        | 10    |
-| [TRX-USDT](adapter/trx-usdt.adapter.json)     | 0xf7385af79a7201e79185c79ff80dfa9d39960bb5c0d62e837477e0f0a87df716 | 8        | 8     |
+| [TRX-USDT](adapter/trx-usdt.adapter.json)     | 0xa18dbcc041ad0373929711bc3570e7da99659a370db1665699092a5b231dd8fe | 8        | 7     |
 | [USDC-USDT](adapter/usdc-usdt.adapter.json)   | 0x04c991c1f0504684d1d4f4bd689066c08f9b32bea47746510590489e810eb23d | 8        | 8     |
 | [XRP-USDT](adapter/xrp-usdt.adapter.json)     | 0x61dc4a3225212016c0cbe5deffa1db31e01837fb0a061ff1cf355650287e0162 | 8        | 10    |
 
@@ -56,6 +56,6 @@
 | [MATIC-USDT](aggregator/default/matic-usdt.aggregator.json) | -              | -       | 15000     | 0.05      | 0.1               | 0xaac691986b90ba59358d2b8bff58036bcfea21cbd9f82ab08915902bdb00cdb1 |
 | [SHIB-USDT](aggregator/default/shib-usdt.aggregator.json)   | -              | -       | 15000     | 0.05      | 0.1               | 0x8300f3385e5843e0da2504964067ab0d81de054550826e60577602e50cffe48c |
 | [SOL-USDT](aggregator/default/sol-usdt.aggregator.json)     | -              | -       | 15000     | 0.05      | 0.1               | 0xf8ba3eafdf66c135dcd093dbb1bfdb10dca956ee3c75b510f76407353eb251d0 |
-| [TRX-USDT](aggregator/default/trx-usdt.aggregator.json)     | -              | -       | 15000     | 0.05      | 0.1               | 0xf7385af79a7201e79185c79ff80dfa9d39960bb5c0d62e837477e0f0a87df716 |
+| [TRX-USDT](aggregator/default/trx-usdt.aggregator.json)     | -              | -       | 15000     | 0.05      | 0.1               | 0xa18dbcc041ad0373929711bc3570e7da99659a370db1665699092a5b231dd8fe |
 | [USDC-USDT](aggregator/default/usdc-usdt.aggregator.json)   | -              | -       | 15000     | 0.05      | 0.1               | 0x04c991c1f0504684d1d4f4bd689066c08f9b32bea47746510590489e810eb23d |
 | [XRP-USDT](aggregator/default/xrp-usdt.aggregator.json)     | -              | -       | 15000     | 0.05      | 0.1               | 0x61dc4a3225212016c0cbe5deffa1db31e01837fb0a061ff1cf355650287e0162 |

--- a/adapter/trx-usdt.adapter.json
+++ b/adapter/trx-usdt.adapter.json
@@ -1,5 +1,5 @@
 {
-  "adapterHash": "0xf7385af79a7201e79185c79ff80dfa9d39960bb5c0d62e837477e0f0a87df716",
+  "adapterHash": "0xa18dbcc041ad0373929711bc3570e7da99659a370db1665699092a5b231dd8fe",
   "name": "TRX-USDT",
   "decimals": 8,
   "feeds": [
@@ -96,29 +96,6 @@
           {
             "function": "PARSE",
             "args": ["indexPrice"]
-          },
-          {
-            "function": "POW10",
-            "args": 8
-          },
-          {
-            "function": "ROUND"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bittrex-TRX-USDT",
-      "definition": {
-        "url": "https://api.bittrex.com/v3/markets/TRX-USDT/ticker",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "method": "GET",
-        "reducers": [
-          {
-            "function": "PARSE",
-            "args": ["lastTradeRate"]
           },
           {
             "function": "POW10",

--- a/aggregator/default/trx-usdt.aggregator.json
+++ b/aggregator/default/trx-usdt.aggregator.json
@@ -5,5 +5,5 @@
   "heartbeat": 15000,
   "threshold": 0.05,
   "absoluteThreshold": 0.1,
-  "adapterHash": "0xf7385af79a7201e79185c79ff80dfa9d39960bb5c0d62e837477e0f0a87df716"
+  "adapterHash": "0xa18dbcc041ad0373929711bc3570e7da99659a370db1665699092a5b231dd8fe"
 }

--- a/script/generateReadme.py
+++ b/script/generateReadme.py
@@ -94,10 +94,9 @@ def checkHashMatch():
 
 checkHashMatch()
 
-print('# Orakl Config\n')
 print('## Adapter\n')
 generateAdapterList()
-print('## Aggregator Baobab\n')
+print('\n## Aggregator Baobab\n')
 generateAggregatorList(aggregatorBaobabPath, aggregatorsBaobab)
-print('## Aggregator Default\n')
+print('\n## Aggregator Default\n')
 generateAggregatorList(aggregatorDefaultPath, aggregatorsDefault)


### PR DESCRIPTION
The trading volume of TRX-USDT on Bittrex is small leading the infrequent updates of data source. Bittrex TRX-USDT data source negatively affects quality of TRX-USDT data feed, therefore we decided to remove it.

![image](https://user-images.githubusercontent.com/2312761/230565635-8b79c9b7-37bb-46d0-9e19-6dfe1833b647.png)
