### PR TITLE
connect `trx-usdt` aggregator with latest adapter

### DIFF
--- a/aggregator/baobab/trx-usdt.aggregator.json
+++ b/aggregator/baobab/trx-usdt.aggregator.json
@@ -1,9 +1,9 @@
 {
-  "aggregatorHash": "0x6299029414ddcff77d22a2145a8666df212f2c3813914292ed459de223b97b7c",
+  "aggregatorHash": "0x5c7e2bfe50cc780ede1769dd166a8e1840dca5c971bf4f3b659ff0eaa6eae7e6",
   "name": "TRX-USDT",
   "address": "0x70eF30152a6d37032831DcA7A78890584b4919f5",
   "heartbeat": 15000,
   "threshold": 0.05,
   "absoluteThreshold": 0.1,
-  "adapterHash": "0xf7385af79a7201e79185c79ff80dfa9d39960bb5c0d62e837477e0f0a87df716"
+  "adapterHash": "0xa18dbcc041ad0373929711bc3570e7da99659a370db1665699092a5b231dd8fe"
 }


### PR DESCRIPTION
This PR is for connect `trx-usdt` aggregator with latest adapter. 
 