### PR TITLE
Add MNR/KRW feed

### DIFF
--- a/adapter/mnr-krw.adapter.json
+++ b/adapter/mnr-krw.adapter.json
@@ -1,0 +1,38 @@
+{
+  "adapterHash": "0x343d0b550e7e286aa9f966a738d48877a550fa52521196b31f3f314809253cf6",
+  "name": "MNR-KRW",
+  "decimals": 8,
+  "feeds": [
+    {
+      "name": "Coinone-MNR-KRW",
+      "definition": {
+        "url": "https://api.coinone.co.kr/public/v2/ticker_new/KRW/MNR",
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "GET",
+        "reducers": [
+          {
+            "function": "PARSE",
+            "args": ["tickers"]
+          },
+          {
+            "function": "INDEX",
+            "args": 0
+          },
+          {
+            "function": "PARSE",
+            "args": ["last"]
+          },
+          {
+            "function": "POW10",
+            "args": 8
+          },
+          {
+            "function": "ROUND"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/aggregator/baobab/mnr-krw.aggregator.json
+++ b/aggregator/baobab/mnr-krw.aggregator.json
@@ -1,7 +1,7 @@
 {
   "aggregatorHash": "0x4f864798f40a3ad4163400b31d493cf9cf03aa4dd9ce1153b9bda5e47cf6ecaa",
   "name": "MNR-KRW",
-  "address": "",
+  "address": "0x04c02234A9EFC6d4cFc94EBbDF0dD61AE5A73227",
   "heartbeat": 15000,
   "threshold": 0.05,
   "absoluteThreshold": 0.1,

--- a/aggregator/default/mnr-krw.aggregator.json
+++ b/aggregator/default/mnr-krw.aggregator.json
@@ -1,0 +1,9 @@
+{
+  "aggregatorHash": "",
+  "name": "MNR-KRW",
+  "address": "",
+  "heartbeat": 15000,
+  "threshold": 0.05,
+  "absoluteThreshold": 0.1,
+  "adapterHash": "0x343d0b550e7e286aa9f966a738d48877a550fa52521196b31f3f314809253cf6"
+}


### PR DESCRIPTION
MNR/KRW is currently being traded only on [Coinone CEX](https://coinone.co.kr/), therefore we use only a single data source to provide MNR/KRW data feed.