### PR TITLE
chore: remove sources for pairs the exchange does not list

### DIFF
--- a/baobab_configs.json
+++ b/baobab_configs.json
@@ -7533,15 +7533,6 @@
         }
       },
       {
-        "name": "kucoin-wss-FORM-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "kucoin",
-          "base": "FORM",
-          "quote": "USDT"
-        }
-      },
-      {
         "name": "gateio-wss-FORM-USDT",
         "definition": {
           "type": "wss",
@@ -13756,15 +13747,6 @@
         "definition": {
           "type": "wss",
           "provider": "bitget",
-          "base": "PAXG",
-          "quote": "USDT"
-        }
-      },
-      {
-        "name": "mexc-wss-PAXG-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "mexc",
           "base": "PAXG",
           "quote": "USDT"
         }
@@ -20944,15 +20926,6 @@
         "definition": {
           "type": "wss",
           "provider": "huobi",
-          "base": "XAUT",
-          "quote": "USDT"
-        }
-      },
-      {
-        "name": "mexc-wss-XAUT-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "mexc",
           "base": "XAUT",
           "quote": "USDT"
         }

--- a/config/baobab/FORM-USDT.config.json
+++ b/config/baobab/FORM-USDT.config.json
@@ -15,15 +15,6 @@
       }
     },
     {
-      "name": "kucoin-wss-FORM-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "kucoin",
-        "base": "FORM",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "gateio-wss-FORM-USDT",
       "definition": {
         "type": "wss",

--- a/config/baobab/PAXG-USDT.config.json
+++ b/config/baobab/PAXG-USDT.config.json
@@ -69,15 +69,6 @@
       }
     },
     {
-      "name": "mexc-wss-PAXG-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "mexc",
-        "base": "PAXG",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "bingx-wss-PAXG-USDT",
       "definition": {
         "type": "wss",

--- a/config/baobab/XAUT-USDT.config.json
+++ b/config/baobab/XAUT-USDT.config.json
@@ -60,15 +60,6 @@
       }
     },
     {
-      "name": "mexc-wss-XAUT-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "mexc",
-        "base": "XAUT",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "okx-wss-XAUT-USDT",
       "definition": {
         "type": "wss",

--- a/config/cypress/FORM-USDT.config.json
+++ b/config/cypress/FORM-USDT.config.json
@@ -15,15 +15,6 @@
       }
     },
     {
-      "name": "kucoin-wss-FORM-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "kucoin",
-        "base": "FORM",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "gateio-wss-FORM-USDT",
       "definition": {
         "type": "wss",

--- a/config/cypress/PAXG-USDT.config.json
+++ b/config/cypress/PAXG-USDT.config.json
@@ -69,15 +69,6 @@
       }
     },
     {
-      "name": "mexc-wss-PAXG-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "mexc",
-        "base": "PAXG",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "bingx-wss-PAXG-USDT",
       "definition": {
         "type": "wss",

--- a/config/cypress/XAUT-USDT.config.json
+++ b/config/cypress/XAUT-USDT.config.json
@@ -60,15 +60,6 @@
       }
     },
     {
-      "name": "mexc-wss-XAUT-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "mexc",
-        "base": "XAUT",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "okx-wss-XAUT-USDT",
       "definition": {
         "type": "wss",

--- a/cypress_configs.json
+++ b/cypress_configs.json
@@ -7559,15 +7559,6 @@
         }
       },
       {
-        "name": "kucoin-wss-FORM-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "kucoin",
-          "base": "FORM",
-          "quote": "USDT"
-        }
-      },
-      {
         "name": "gateio-wss-FORM-USDT",
         "definition": {
           "type": "wss",
@@ -13843,15 +13834,6 @@
         "definition": {
           "type": "wss",
           "provider": "bitget",
-          "base": "PAXG",
-          "quote": "USDT"
-        }
-      },
-      {
-        "name": "mexc-wss-PAXG-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "mexc",
           "base": "PAXG",
           "quote": "USDT"
         }
@@ -21042,15 +21024,6 @@
         "definition": {
           "type": "wss",
           "provider": "huobi",
-          "base": "XAUT",
-          "quote": "USDT"
-        }
-      },
-      {
-        "name": "mexc-wss-XAUT-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "mexc",
           "base": "XAUT",
           "quote": "USDT"
         }


### PR DESCRIPTION
## What

Three feed sources point at pairs the exchange **does not list**, so they have never produced data. Same three on **both networks**:

| pair | source | evidence |
|---|---|---|
| FORM-USDT | `kucoin` | absent from `GET api.kucoin.com/api/v2/symbols` |
| PAXG-USDT | `mexc` | absent from `GET api.mexc.com/api/v3/exchangeInfo` |
| XAUT-USDT | `mexc` | absent from `GET api.mexc.com/api/v3/exchangeInfo` |

## Why now

These are **not** the same problem as the kucoin/mexc outages fixed in Bisonai/orakl#2510 and Bisonai/orakl#2511. Those were *code bugs* that killed **every** symbol on both providers (~270 feeds) — which is exactly why these three weren't distinguishable from the rest until the providers were working again.

With the providers fixed, I swept all 266 kucoin + mexc sources against the live exchange listings. These three are the **only** ones the exchanges genuinely don't carry; everything else is now confirmed live.

## Safety

Each pair keeps plenty of sources, nowhere near the LocalAggregator quorum:

| pair | before | after |
|---|---|---|
| FORM-USDT | 11 | **10** |
| PAXG-USDT | 12 | **11** |
| XAUT-USDT | 15 | **14** |

## Formatting

Removed from both the per-pair config and the compiled bundle. Verified as **pure deletions — 0 lines added, 108 removed** — so the generator scripts' formatting is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)