### PR TITLE
Remove the delisted OrangeX source from the GRND-USDT feed

### DIFF
--- a/baobab_configs.json
+++ b/baobab_configs.json
@@ -8304,15 +8304,6 @@
           "base": "GRND",
           "quote": "USDT"
         }
-      },
-      {
-        "name": "orangex-wss-GRND-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "orangex",
-          "base": "GRND",
-          "quote": "USDT"
-        }
       }
     ],
     "feedDataFreshness": 60000

--- a/config/baobab/GRND-USDT.config.json
+++ b/config/baobab/GRND-USDT.config.json
@@ -22,15 +22,6 @@
         "base": "GRND",
         "quote": "USDT"
       }
-    },
-    {
-      "name": "orangex-wss-GRND-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "orangex",
-        "base": "GRND",
-        "quote": "USDT"
-      }
     }
   ]
 }

--- a/config/cypress/GRND-USDT.config.json
+++ b/config/cypress/GRND-USDT.config.json
@@ -22,15 +22,6 @@
         "base": "GRND",
         "quote": "USDT"
       }
-    },
-    {
-      "name": "orangex-wss-GRND-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "orangex",
-        "base": "GRND",
-        "quote": "USDT"
-      }
     }
   ]
 }

--- a/cypress_configs.json
+++ b/cypress_configs.json
@@ -8343,15 +8343,6 @@
           "base": "GRND",
           "quote": "USDT"
         }
-      },
-      {
-        "name": "orangex-wss-GRND-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "orangex",
-          "base": "GRND",
-          "quote": "USDT"
-        }
       }
     ],
     "feedDataFreshness": 60000


### PR DESCRIPTION
## Problem (reported by Rhombus Protocol)

On-chain **GRND-USDT is stuck at \$0.12** on both networks while the real price is **~\$0.01**.

Root cause — **OrangeX delisted GRND-USDT** (its REST returns `Instrument does not exist`), but its websocket keeps pushing a **frozen 0.12** that the node still treats as fresh. It's the **only** price the aggregator collects:

```
collected prices: [12000000]   ← 0.12, from OrangeX only
```

The other sources on the node:
- **gateio** — correct (`0.01011`) but currently **stale** (last tick ~23 min ago)
- **lbank** — `currency pair nonsupport` (delisted)

So OrangeX's frozen 0.12 wins by default. (Same delisting pattern as IP-USDT earlier.)

## Change

Remove `orangex-wss-GRND-USDT` from both networks (individual config + compiled bundle). Pure deletion, formatting preserved (0 lines added, 36 removed).

**lbank is intentionally kept** — dropping it too would leave a single-source feed, collapsing the quorum guard (`len(feeds)/2`) to 0 and letting an empty aggregate through. With gateio+lbank it stays at 1, so gateio alone suffices when it ticks and an all-stale round correctly produces no update.

## After merge

`config.orakl.network` (GitHub Pages) rebuilds, then I'll `config/sync` + `fetcher/aggregator refresh` on the **bisonai** and **KF** nodes and confirm GRND-USDT drops the 0.12 and tracks gateio.

⚠️ Live mainnet oracle feeding Rhombus Protocol — please merge when you can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)