### PR TITLE
Remove the delisted LBank source from the GRND-USDT feed

### DIFF
--- a/baobab_configs.json
+++ b/baobab_configs.json
@@ -8286,15 +8286,6 @@
           "base": "GRND",
           "quote": "USDT"
         }
-      },
-      {
-        "name": "lbank-wss-GRND-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "lbank",
-          "base": "GRND",
-          "quote": "USDT"
-        }
       }
     ],
     "feedDataFreshness": 60000

--- a/config/baobab/GRND-USDT.config.json
+++ b/config/baobab/GRND-USDT.config.json
@@ -13,15 +13,6 @@
         "base": "GRND",
         "quote": "USDT"
       }
-    },
-    {
-      "name": "lbank-wss-GRND-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "lbank",
-        "base": "GRND",
-        "quote": "USDT"
-      }
     }
   ]
 }

--- a/config/cypress/GRND-USDT.config.json
+++ b/config/cypress/GRND-USDT.config.json
@@ -13,15 +13,6 @@
         "base": "GRND",
         "quote": "USDT"
       }
-    },
-    {
-      "name": "lbank-wss-GRND-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "lbank",
-        "base": "GRND",
-        "quote": "USDT"
-      }
     }
   ]
 }

--- a/cypress_configs.json
+++ b/cypress_configs.json
@@ -8325,15 +8325,6 @@
           "base": "GRND",
           "quote": "USDT"
         }
-      },
-      {
-        "name": "lbank-wss-GRND-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "lbank",
-          "base": "GRND",
-          "quote": "USDT"
-        }
       }
     ],
     "feedDataFreshness": 60000


### PR DESCRIPTION
Follow-up to #197 (OrangeX). **LBank also delisted GRND-USDT** — its API returns `currency pair nonsupport` — so this source never produces data and is only ever excluded as stale.

## Why I kept it in #197 (and why it's actually safe to drop)

I left LBank in out of caution: dropping to a **single** configured source collapses the LocalAggregator quorum guard `len(feeds) < len(c.Feeds)/2` to `0 < 0` (false), so an all-stale round falls through to the aggregation path with **zero feeds**.

But that path is safe:
- `calculateVWAP([])` → `0`, `calculateMedian([])` → `0`
- `calculateAggregatedPrice(0,0)` → `0`
- `streamLocalAggregate` → **`if aggregated == 0 { return nil }`** → the round is **skipped, not published**

So a zeroed aggregate is never submitted; the feed just doesn't update. No reason to keep a dead source.

## Result

GRND-USDT is now **single-source (gateio)**. It's correct and currently fresh. ⚠️ Worth adding another live source when one exists, for resilience — right now gateio is the only exchange we track that still lists GRND-USDT.

After merge: `config/sync` + refresh on the nodes (same as #197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)