### PR TITLE
Add HashKey Global as a second GRND-USDT source

### DIFF
--- a/baobab_configs.json
+++ b/baobab_configs.json
@@ -8286,6 +8286,15 @@
           "base": "GRND",
           "quote": "USDT"
         }
+      },
+      {
+        "name": "hashkey-wss-GRND-USDT",
+        "definition": {
+          "type": "wss",
+          "provider": "hashkey",
+          "base": "GRND",
+          "quote": "USDT"
+        }
       }
     ],
     "feedDataFreshness": 60000

--- a/config/baobab/GRND-USDT.config.json
+++ b/config/baobab/GRND-USDT.config.json
@@ -13,6 +13,15 @@
         "base": "GRND",
         "quote": "USDT"
       }
+    },
+    {
+      "name": "hashkey-wss-GRND-USDT",
+      "definition": {
+        "type": "wss",
+        "provider": "hashkey",
+        "base": "GRND",
+        "quote": "USDT"
+      }
     }
   ]
 }

--- a/config/cypress/GRND-USDT.config.json
+++ b/config/cypress/GRND-USDT.config.json
@@ -13,6 +13,15 @@
         "base": "GRND",
         "quote": "USDT"
       }
+    },
+    {
+      "name": "hashkey-wss-GRND-USDT",
+      "definition": {
+        "type": "wss",
+        "provider": "hashkey",
+        "base": "GRND",
+        "quote": "USDT"
+      }
     }
   ]
 }

--- a/cypress_configs.json
+++ b/cypress_configs.json
@@ -8325,6 +8325,15 @@
           "base": "GRND",
           "quote": "USDT"
         }
+      },
+      {
+        "name": "hashkey-wss-GRND-USDT",
+        "definition": {
+          "type": "wss",
+          "provider": "hashkey",
+          "base": "GRND",
+          "quote": "USDT"
+        }
       }
     ],
     "feedDataFreshness": 60000


### PR DESCRIPTION
Adds `hashkey-wss-GRND-USDT` to the GRND-USDT feed on both networks.

## Why

GRND-USDT was left **single-source on gateio** after OrangeX and LBank delisted it (#197, #198). HashKey Global lists it with **~4x gateio's volume** and ticks more often — good redundancy and freshness.

## Result

GRND-USDT sources: `gateio` → **`gateio` + `hashkey`**. Pure addition (0 lines removed).

## ⚠️ Ordering

The `hashkey` provider ships in **Bisonai/orakl#2515** (merged). This config only takes effect once a **node image carrying that provider is deployed**. Until then a node that syncs this config simply has no hashkey fetcher for the pair — no error, just inactive. So this can merge any time, but the source goes live only after the new image rolls out (I'll build + deploy that next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)