### PR TITLE
Teach the config generator about HashKey Global

### DIFF
--- a/script/generate-configs.py
+++ b/script/generate-configs.py
@@ -37,6 +37,19 @@ def get_binance_symbols(url):
         result.append(entry["symbol"].lower())
     return result
 
+
+# HashKey Global's exchangeInfo is Binance-format (a "symbols" array whose
+# entries carry a "status" of "TRADING"), so the parsing matches binance.
+def get_hashkey_symbols(url):
+    result = []
+    json_data = load_json_from_url(url)
+    symbols = json_data["symbols"]
+    for entry in symbols:
+        if entry["status"] != "TRADING":
+            continue
+        result.append(entry["symbol"].lower())
+    return result
+
 def get_coinbase_symbols(url):
     result = []
     json_data = load_json_from_url(url)
@@ -312,6 +325,9 @@ def store_symbols(urls_path, symbols_path):
 
     result["orangex"] = get_orangex_symbols(urls["orangex"])
     print("orangex symbol loaded")
+
+    result["hashkey"] = get_hashkey_symbols(urls["hashkey"])
+    print("hashkey symbol loaded")
 
 
     with open(symbols_path, "w") as f:

--- a/script/urls.json
+++ b/script/urls.json
@@ -23,5 +23,6 @@
   "bitmart": "https://api-cloud.bitmart.com/spot/v1/symbols",
   "xt": "https://sapi.xt.com/v4/public/symbol",
   "gopax": "https://api.gopax.co.kr/trading-pairs",
-  "orangex": "https://api.orangex.com/api/v1/public/get_instruments?currency=spot"
+  "orangex": "https://api.orangex.com/api/v1/public/get_instruments?currency=spot",
+  "hashkey": "https://api-glb.hashkey.com/api/v1/exchangeInfo"
 }


### PR DESCRIPTION
Adds **HashKey Global** to the config-generation pipeline so future configs can pull it as a source. (The fetcher provider itself is in Bisonai/orakl#2515.)

- **urls.json**: `hashkey` → `https://api-glb.hashkey.com/api/v1/exchangeInfo`
- **generate-configs.py**: `get_hashkey_symbols` + its dispatch line. HashKey Global's exchangeInfo is Binance-format (a `symbols` array with `"status":"TRADING"`), so the parser mirrors `get_binance_symbols`.

Verified live: 37 symbols parsed, `grndusdt` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)