### PR TITLE
Remove the capybara sources from the KAIA-USDT feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 | [FLOKI-USDT](config/baobab/FLOKI-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [FLOW-KRW](config/baobab/FLOW-KRW.config.json) | 2000 | 400 | 60000 | 1 |
 | [FLR-USDT](config/baobab/FLR-USDT.config.json) | 2000 | 400 | 60000 | 11 |
-| [FORM-USDT](config/baobab/FORM-USDT.config.json) | 2000 | 400 | 60000 | 11 |
+| [FORM-USDT](config/baobab/FORM-USDT.config.json) | 2000 | 400 | 60000 | 10 |
 | [FTT-USDT](config/baobab/FTT-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [GALA-USDT](config/baobab/GALA-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [GAS-KRW](config/baobab/GAS-KRW.config.json) | 2000 | 400 | 60000 | 3 |
@@ -91,7 +91,7 @@
 | [GNO-USDT](config/baobab/GNO-USDT.config.json) | 2000 | 400 | 60000 | 9 |
 | [GRASS-USDT](config/baobab/GRASS-USDT.config.json) | 2000 | 400 | 60000 | 10 |
 | [GRND-KRW](config/baobab/GRND-KRW.config.json) | 2000 | 400 | 60000 | 2 |
-| [GRND-USDT](config/baobab/GRND-USDT.config.json) | 2000 | 400 | 60000 | 3 |
+| [GRND-USDT](config/baobab/GRND-USDT.config.json) | 2000 | 400 | 60000 | 2 |
 | [GRT-KRW](config/baobab/GRT-KRW.config.json) | 2000 | 400 | 60000 | 4 |
 | [GT-USDT](config/baobab/GT-USDT.config.json) | 2000 | 400 | 60000 | 3 |
 | [HBAR-KRW](config/baobab/HBAR-KRW.config.json) | 2000 | 400 | 60000 | 4 |
@@ -112,7 +112,7 @@
 | [JTO-USDT](config/baobab/JTO-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [JUP-USDT](config/baobab/JUP-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [KAIA-KRW](config/baobab/KAIA-KRW.config.json) | 2000 | 400 | 60000 | 4 |
-| [KAIA-USDT](config/baobab/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 17 |
+| [KAIA-USDT](config/baobab/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [KAITO-USDT](config/baobab/KAITO-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAS-USDT](config/baobab/KAS-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAVA-USDT](config/baobab/KAVA-USDT.config.json) | 2000 | 400 | 60000 | 13 |
@@ -150,7 +150,7 @@
 | [ONDO-USDT](config/baobab/ONDO-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [ONG-KRW](config/baobab/ONG-KRW.config.json) | 2000 | 400 | 60000 | 3 |
 | [OSMO-USDT](config/baobab/OSMO-USDT.config.json) | 2000 | 400 | 60000 | 11 |
-| [PAXG-USDT](config/baobab/PAXG-USDT.config.json) | 2000 | 400 | 15000 | 12 |
+| [PAXG-USDT](config/baobab/PAXG-USDT.config.json) | 2000 | 400 | 15000 | 11 |
 | [PENDLE-USDT](config/baobab/PENDLE-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [PENGU-USDT](config/baobab/PENGU-USDT.config.json) | 2000 | 400 | 60000 | 17 |
 | [PEPE-KRW](config/baobab/PEPE-KRW.config.json) | 2000 | 400 | 60000 | 4 |
@@ -220,7 +220,7 @@
 | [WIF-USDT](config/baobab/WIF-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [WLD-KRW](config/baobab/WLD-KRW.config.json) | 2000 | 400 | 60000 | 4 |
 | [WLD-USDT](config/baobab/WLD-USDT.config.json) | 2000 | 400 | 60000 | 15 |
-| [XAUT-USDT](config/baobab/XAUT-USDT.config.json) | 2000 | 400 | 60000 | 15 |
+| [XAUT-USDT](config/baobab/XAUT-USDT.config.json) | 2000 | 400 | 60000 | 14 |
 | [XCH-USDT](config/baobab/XCH-USDT.config.json) | 2000 | 400 | 60000 | 9 |
 | [XCN-USDT](config/baobab/XCN-USDT.config.json) | 2000 | 400 | 60000 | 9 |
 | [XEC-KRW](config/baobab/XEC-KRW.config.json) | 2000 | 400 | 60000 | 5 |
@@ -322,7 +322,7 @@
 | [FLOKI-USDT](config/cypress/FLOKI-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [FLOW-KRW](config/cypress/FLOW-KRW.config.json) | 2000 | 400 | 60000 | 1 |
 | [FLR-USDT](config/cypress/FLR-USDT.config.json) | 2000 | 400 | 60000 | 11 |
-| [FORM-USDT](config/cypress/FORM-USDT.config.json) | 2000 | 400 | 60000 | 11 |
+| [FORM-USDT](config/cypress/FORM-USDT.config.json) | 2000 | 400 | 60000 | 10 |
 | [FTT-USDT](config/cypress/FTT-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [GALA-USDT](config/cypress/GALA-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [GAS-KRW](config/cypress/GAS-KRW.config.json) | 2000 | 400 | 60000 | 3 |
@@ -331,7 +331,7 @@
 | [GNO-USDT](config/cypress/GNO-USDT.config.json) | 2000 | 400 | 60000 | 9 |
 | [GRASS-USDT](config/cypress/GRASS-USDT.config.json) | 2000 | 400 | 60000 | 10 |
 | [GRND-KRW](config/cypress/GRND-KRW.config.json) | 2000 | 400 | 60000 | 2 |
-| [GRND-USDT](config/cypress/GRND-USDT.config.json) | 2000 | 400 | 60000 | 3 |
+| [GRND-USDT](config/cypress/GRND-USDT.config.json) | 2000 | 400 | 60000 | 2 |
 | [GRT-KRW](config/cypress/GRT-KRW.config.json) | 2000 | 400 | 60000 | 4 |
 | [GT-USDT](config/cypress/GT-USDT.config.json) | 2000 | 400 | 60000 | 3 |
 | [HBAR-KRW](config/cypress/HBAR-KRW.config.json) | 2000 | 400 | 60000 | 4 |
@@ -352,7 +352,7 @@
 | [JTO-USDT](config/cypress/JTO-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [JUP-USDT](config/cypress/JUP-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [KAIA-KRW](config/cypress/KAIA-KRW.config.json) | 2000 | 400 | 60000 | 4 |
-| [KAIA-USDT](config/cypress/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 17 |
+| [KAIA-USDT](config/cypress/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [KAITO-USDT](config/cypress/KAITO-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAS-USDT](config/cypress/KAS-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAVA-USDT](config/cypress/KAVA-USDT.config.json) | 2000 | 400 | 60000 | 13 |
@@ -390,7 +390,7 @@
 | [ONDO-USDT](config/cypress/ONDO-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [ONG-KRW](config/cypress/ONG-KRW.config.json) | 2000 | 400 | 60000 | 3 |
 | [OSMO-USDT](config/cypress/OSMO-USDT.config.json) | 2000 | 400 | 60000 | 11 |
-| [PAXG-USDT](config/cypress/PAXG-USDT.config.json) | 2000 | 400 | 15000 | 12 |
+| [PAXG-USDT](config/cypress/PAXG-USDT.config.json) | 2000 | 400 | 15000 | 11 |
 | [PENDLE-USDT](config/cypress/PENDLE-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [PENGU-USDT](config/cypress/PENGU-USDT.config.json) | 2000 | 400 | 60000 | 17 |
 | [PEPE-KRW](config/cypress/PEPE-KRW.config.json) | 2000 | 400 | 60000 | 4 |
@@ -460,7 +460,7 @@
 | [WIF-USDT](config/cypress/WIF-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [WLD-KRW](config/cypress/WLD-KRW.config.json) | 2000 | 400 | 60000 | 4 |
 | [WLD-USDT](config/cypress/WLD-USDT.config.json) | 2000 | 400 | 60000 | 15 |
-| [XAUT-USDT](config/cypress/XAUT-USDT.config.json) | 2000 | 400 | 60000 | 15 |
+| [XAUT-USDT](config/cypress/XAUT-USDT.config.json) | 2000 | 400 | 60000 | 14 |
 | [XCH-USDT](config/cypress/XCH-USDT.config.json) | 2000 | 400 | 60000 | 9 |
 | [XCN-USDT](config/cypress/XCN-USDT.config.json) | 2000 | 400 | 60000 | 9 |
 | [XEC-KRW](config/cypress/XEC-KRW.config.json) | 2000 | 400 | 60000 | 5 |

--- a/baobab_configs.json
+++ b/baobab_configs.json
@@ -10070,30 +10070,6 @@
           "base": "KAIA",
           "quote": "USDT"
         }
-      },
-      {
-        "name": "capybara-KAIA-USDT(Wormhole)",
-        "definition": {
-          "chainId": "8217",
-          "address": "0x6389dbfa1427a3b0a89cddc7ea9bbda6e73dece7",
-          "type": "CapybaraPool",
-          "token0Decimals": 18,
-          "token1Decimals": 6,
-          "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-          "token1Address": "0x5c13e303a62fc5dedf5b52d66873f2e59fedadc2"
-        }
-      },
-      {
-        "name": "capybara-KAIA-USDT(Stargate)",
-        "definition": {
-          "chainId": "8217",
-          "address": "0x1de1578476d9b4237f963eca5d37500fc33df3d1",
-          "type": "CapybaraPool",
-          "token0Decimals": 18,
-          "token1Decimals": 6,
-          "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-          "token1Address": "0x9025095263d1e548dc890a7589a4c78038ac40ab"
-        }
       }
     ],
     "feedDataFreshness": 60000

--- a/config/baobab/KAIA-USDT.config.json
+++ b/config/baobab/KAIA-USDT.config.json
@@ -139,30 +139,6 @@
         "base": "KAIA",
         "quote": "USDT"
       }
-    },
-    {
-      "name": "capybara-KAIA-USDT(Wormhole)",
-      "definition": {
-        "chainId": "8217",
-        "address": "0x6389dbfa1427a3b0a89cddc7ea9bbda6e73dece7",
-        "type": "CapybaraPool",
-        "token0Decimals": 18,
-        "token1Decimals": 6,
-        "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-        "token1Address": "0x5c13e303a62fc5dedf5b52d66873f2e59fedadc2"
-      }
-    },
-    {
-      "name": "capybara-KAIA-USDT(Stargate)",
-      "definition": {
-        "chainId": "8217",
-        "address": "0x1de1578476d9b4237f963eca5d37500fc33df3d1",
-        "type": "CapybaraPool",
-        "token0Decimals": 18,
-        "token1Decimals": 6,
-        "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-        "token1Address": "0x9025095263d1e548dc890a7589a4c78038ac40ab"
-      }
     }
   ]
 }

--- a/config/cypress/KAIA-USDT.config.json
+++ b/config/cypress/KAIA-USDT.config.json
@@ -139,30 +139,6 @@
         "base": "KAIA",
         "quote": "USDT"
       }
-    },
-    {
-      "name": "capybara-KAIA-USDT(Wormhole)",
-      "definition": {
-        "chainId": "8217",
-        "address": "0x6389dbfa1427a3b0a89cddc7ea9bbda6e73dece7",
-        "type": "CapybaraPool",
-        "token0Decimals": 18,
-        "token1Decimals": 6,
-        "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-        "token1Address": "0x5c13e303a62fc5dedf5b52d66873f2e59fedadc2"
-      }
-    },
-    {
-      "name": "capybara-KAIA-USDT(Stargate)",
-      "definition": {
-        "chainId": "8217",
-        "address": "0x1de1578476d9b4237f963eca5d37500fc33df3d1",
-        "type": "CapybaraPool",
-        "token0Decimals": 18,
-        "token1Decimals": 6,
-        "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-        "token1Address": "0x9025095263d1e548dc890a7589a4c78038ac40ab"
-      }
     }
   ]
 }

--- a/cypress_configs.json
+++ b/cypress_configs.json
@@ -10133,30 +10133,6 @@
           "base": "KAIA",
           "quote": "USDT"
         }
-      },
-      {
-        "name": "capybara-KAIA-USDT(Wormhole)",
-        "definition": {
-          "chainId": "8217",
-          "address": "0x6389dbfa1427a3b0a89cddc7ea9bbda6e73dece7",
-          "type": "CapybaraPool",
-          "token0Decimals": 18,
-          "token1Decimals": 6,
-          "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-          "token1Address": "0x5c13e303a62fc5dedf5b52d66873f2e59fedadc2"
-        }
-      },
-      {
-        "name": "capybara-KAIA-USDT(Stargate)",
-        "definition": {
-          "chainId": "8217",
-          "address": "0x1de1578476d9b4237f963eca5d37500fc33df3d1",
-          "type": "CapybaraPool",
-          "token0Decimals": 18,
-          "token1Decimals": 6,
-          "token0Address": "0x19aac5f612f524b754ca7e7c41cbfa2e981a4432",
-          "token1Address": "0x9025095263d1e548dc890a7589a4c78038ac40ab"
-        }
       }
     ],
     "feedDataFreshness": 60000


### PR DESCRIPTION
## Summary

Removes both `CapybaraPool` entries from the KAIA-USDT feed on **both** networks:

- `capybara-KAIA-USDT(Wormhole)` — `0x6389dbfa1427a3b0a89cddc7ea9bbda6e73dece7`
- `capybara-KAIA-USDT(Stargate)` — `0x1de1578476d9b4237f963eca5d37500fc33df3d1`

Four config files, 96 deletions — the same shape as #198 (LBank/GRND) and #197 (OrangeX/GRND):

| file | |
|---|---|
| `config/baobab/KAIA-USDT.config.json` | per-file config |
| `config/cypress/KAIA-USDT.config.json` | per-file config |
| `baobab_configs.json` | generated bundle |
| `cypress_configs.json` | generated bundle |

Plus a second commit regenerating `README.md` — see below.

## Impact

- KAIA-USDT drops 17 → **15 feeds** per network, all wss. Well clear of the LocalAggregator quorum guard, so none of the single-source reasoning from #198 applies here.
- No orakl-side change. The `capybara` provider (`node/pkg/websocketfetcher/providers/capybara`) is still used by KRWO-USDT and STKAIA-KAIA.

## README regeneration

`python script/generate-readme.py` is all-or-nothing, so the regen also corrects four rows that had drifted from the configs in earlier commits which skipped it. 10 rows changed in total (each pair on both networks):

| pair | was | now | source |
|---|---|---|---|
| KAIA-USDT | 17 | 15 | this PR |
| GRND-USDT | 3 | 2 | drift (#198/#199) |
| FORM-USDT | 11 | 10 | drift |
| PAXG-USDT | 12 | 11 | drift |
| XAUT-USDT | 15 | 14 | drift |

Nothing else in the file changed, and the script's adapter/aggregator link validation passed.

## Tests

No test suite in this repo. Verified manually:

- All four config files parse as JSON.
- Feed counts are 15 in both the per-file config and the corresponding bundle, on both networks.
- No `capybara-KAIA-USDT` references remain anywhere in the repo.
- Ran `script/collect-files.py` in a scratch copy and confirmed the hand-edited KAIA-USDT bundle entries are **identical** to generator output.
- `script/generate-readme.py` exits 0 with no validation errors; diff limited to the 10 rows above.

## Known issues / not done

- Bundles were hand-edited rather than regenerated. Running `collect-files.py` repo-wide currently rewrites ~49k lines of pre-existing unrelated drift (indentation in `*_configs.json`, plus `*_adapters.json` and `test_configs.json`), so it is left alone here. That drift predates this PR and is worth a separate cleanup.