### PR TITLE
Remove the crypto and huobi sources from the KAIA-USDT feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@
 | [JTO-USDT](config/baobab/JTO-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [JUP-USDT](config/baobab/JUP-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [KAIA-KRW](config/baobab/KAIA-KRW.config.json) | 2000 | 400 | 60000 | 4 |
-| [KAIA-USDT](config/baobab/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 15 |
+| [KAIA-USDT](config/baobab/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAITO-USDT](config/baobab/KAITO-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAS-USDT](config/baobab/KAS-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAVA-USDT](config/baobab/KAVA-USDT.config.json) | 2000 | 400 | 60000 | 13 |
@@ -352,7 +352,7 @@
 | [JTO-USDT](config/cypress/JTO-USDT.config.json) | 2000 | 400 | 60000 | 15 |
 | [JUP-USDT](config/cypress/JUP-USDT.config.json) | 2000 | 400 | 60000 | 16 |
 | [KAIA-KRW](config/cypress/KAIA-KRW.config.json) | 2000 | 400 | 60000 | 4 |
-| [KAIA-USDT](config/cypress/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 15 |
+| [KAIA-USDT](config/cypress/KAIA-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAITO-USDT](config/cypress/KAITO-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAS-USDT](config/cypress/KAS-USDT.config.json) | 2000 | 400 | 60000 | 13 |
 | [KAVA-USDT](config/cypress/KAVA-USDT.config.json) | 2000 | 400 | 60000 | 13 |

--- a/baobab_configs.json
+++ b/baobab_configs.json
@@ -9964,15 +9964,6 @@
         }
       },
       {
-        "name": "crypto-wss-KAIA-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "crypto",
-          "base": "KAIA",
-          "quote": "USDT"
-        }
-      },
-      {
         "name": "btse-wss-KAIA-USDT",
         "definition": {
           "type": "wss",
@@ -10013,15 +10004,6 @@
         "definition": {
           "type": "wss",
           "provider": "bitget",
-          "base": "KAIA",
-          "quote": "USDT"
-        }
-      },
-      {
-        "name": "huobi-wss-KAIA-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "huobi",
           "base": "KAIA",
           "quote": "USDT"
         }

--- a/config/baobab/KAIA-USDT.config.json
+++ b/config/baobab/KAIA-USDT.config.json
@@ -33,15 +33,6 @@
       }
     },
     {
-      "name": "crypto-wss-KAIA-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "crypto",
-        "base": "KAIA",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "btse-wss-KAIA-USDT",
       "definition": {
         "type": "wss",
@@ -82,15 +73,6 @@
       "definition": {
         "type": "wss",
         "provider": "bitget",
-        "base": "KAIA",
-        "quote": "USDT"
-      }
-    },
-    {
-      "name": "huobi-wss-KAIA-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "huobi",
         "base": "KAIA",
         "quote": "USDT"
       }

--- a/config/cypress/KAIA-USDT.config.json
+++ b/config/cypress/KAIA-USDT.config.json
@@ -33,15 +33,6 @@
       }
     },
     {
-      "name": "crypto-wss-KAIA-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "crypto",
-        "base": "KAIA",
-        "quote": "USDT"
-      }
-    },
-    {
       "name": "btse-wss-KAIA-USDT",
       "definition": {
         "type": "wss",
@@ -82,15 +73,6 @@
       "definition": {
         "type": "wss",
         "provider": "bitget",
-        "base": "KAIA",
-        "quote": "USDT"
-      }
-    },
-    {
-      "name": "huobi-wss-KAIA-USDT",
-      "definition": {
-        "type": "wss",
-        "provider": "huobi",
         "base": "KAIA",
         "quote": "USDT"
       }

--- a/cypress_configs.json
+++ b/cypress_configs.json
@@ -10027,15 +10027,6 @@
         }
       },
       {
-        "name": "crypto-wss-KAIA-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "crypto",
-          "base": "KAIA",
-          "quote": "USDT"
-        }
-      },
-      {
         "name": "btse-wss-KAIA-USDT",
         "definition": {
           "type": "wss",
@@ -10076,15 +10067,6 @@
         "definition": {
           "type": "wss",
           "provider": "bitget",
-          "base": "KAIA",
-          "quote": "USDT"
-        }
-      },
-      {
-        "name": "huobi-wss-KAIA-USDT",
-        "definition": {
-          "type": "wss",
-          "provider": "huobi",
           "base": "KAIA",
           "quote": "USDT"
         }


### PR DESCRIPTION
## Summary

Removes two wss sources from the KAIA-USDT feed on **both** networks:

- `crypto-wss-KAIA-USDT` (crypto.com)
- `huobi-wss-KAIA-USDT`

Follow-up to #201, same 4-file shape plus the README regen:

| file | |
|---|---|
| `config/baobab/KAIA-USDT.config.json` | per-file config |
| `config/cypress/KAIA-USDT.config.json` | per-file config |
| `baobab_configs.json` | generated bundle |
| `cypress_configs.json` | generated bundle |
| `README.md` | regenerated |

## Impact

KAIA-USDT drops 15 → **13 feeds** per network, all wss. Well clear of the LocalAggregator quorum guard.

Remaining sources: binance, kucoin, bybit, btse, gateio, lbank, coinex, bitget, okx, bingx, bitmart, xt, orangex.

## Tests

No test suite in this repo. Verified manually:

- All four config files parse as JSON; the diff is **72 deletions, 0 insertions** (only the two blocks, nothing reflowed).
- Feed counts are 13 in both the per-file config and the corresponding bundle, on both networks.
- Ran `script/collect-files.py` in a scratch copy — the hand-edited KAIA-USDT bundle entries are **identical** to generator output.
- `script/generate-readme.py` exits 0 with no validation errors; its diff is exactly the two KAIA-USDT rows (15 → 13), since #201 already cleared the pre-existing drift.

## Note

The commit deliberately states no rationale for dropping these two sources — I don't know whether this is a delisting, a data-quality call, or something else. Worth adding to the commit/PR before merge if it should be on the record, as #197/#198 did.

## After merge

Config is served from GitHub Pages, and the node does not poll. To apply on each network:

```
POST /api/v1/config/sync      # reconcile DB against the published JSON
POST /api/v1/fetcher/refresh  # reload fetchers from DB
```